### PR TITLE
Added Maq Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This Repository contains the list of companies(more than FAANG) which you can jo
       </thead>
       <tbody>
          <tr>
-            <td align="center">341</td>
+            <td align="center">342</td>
          </tr>
       </tbody>
    </table>
@@ -386,6 +386,7 @@ PLEASE DON'T CHANGE THE NUMBERING. KEEP EVERYTHING STARTING WITH 1.
 1.   [MakeMyTrip](https://careers.makemytrip.com/)  
 1.   [Mastercard](https://www.mastercard.us/en-us/vision/who-we-are/careers.html)  
 1.   [Mathworks](https://in.mathworks.com/company/jobs/opportunities.html)
+1.   [Maq Software](https://maqsoftware.com/)
 1.   [Media.net](https://careers.media.net/)  
 1.   [Meesho](https://careers.meesho.com/)  
 1.   [Memory](https://memory.ai/jobs)


### PR DESCRIPTION
Added maq software at its correct place.
The numbering is started with 1.
Also increased the count.

## Congratulations on making a pull request!
### Please make sure you check all the items.

- [x] The numbering of the company that you added starts with ```1```.
- [x] You have increased the ```Total Companies Added``` count.
